### PR TITLE
Simple Precompiler Fixes

### DIFF
--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -53,7 +53,8 @@ patterns:
   match: (?i)\b(?:V|S)_[A-Z]+\b
 
 - name: meta.preprocessor.igor
-  match: '^#pragma'
+  comment: C precompiler statements
+  match: '^#\w+'
 
 - name: meta.function-call.igor
   begin: (?i)(MatrixOP|ApMath)

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -155,8 +155,10 @@
 			<string>support.variable.igor</string>
 		</dict>
 		<dict>
+			<key>comment</key>
+			<string>C precompiler statements</string>
 			<key>match</key>
-			<string>^#pragma</string>
+			<string>^#\w+</string>
 			<key>name</key>
 			<string>meta.preprocessor.igor</string>
 		</dict>


### PR DESCRIPTION
Include all precompiler statements. Does not check for valid syntax here.

Closes #2