### PR TITLE
Add Mappings Around Github Colors

### DIFF
--- a/colors.php
+++ b/colors.php
@@ -1,0 +1,123 @@
+<p>Github color identifier based on <a href="https://graphicdesign.stackexchange.com/a/92987/134191"> this stackexchange post</a> with github colors from <a href="https://github.com/github/linguist/pull/4568#issuecomment-513739638">this post</a> on 2019-07-22:</p>
+
+<?php
+
+function distance_3d($rgb_1, $rgb_2) {
+  return round(sqrt(pow($rgb_1[0] - $rgb_2[0], 2) +
+              pow($rgb_1[1] - $rgb_2[1], 2) +
+              pow($rgb_1[2] - $rgb_2[2], 2)));
+}
+
+if (isset($_POST["hexcode"])) {
+  $hexcode = $_POST["hexcode"];
+  $r = hexdec(substr($hexcode, 0, 2));
+  $g = hexdec(substr($hexcode, 2, 2));
+  $b = hexdec(substr($hexcode, 4, 2));
+  $rgb = [$r, $g, $b];
+
+  $basic_colors = [
+    'black' => [0, 0, 0],
+    'white' => [255, 255, 255],
+    'red' => [255, 0, 0],
+    'orange' => [255, 128, 0],
+    'yellow' => [255, 255, 0],
+    'chartreuse' => [128, 255, 0],
+    'green' => [0, 255, 0],
+    'spring green' => [0, 255, 128],
+    'cyan' => [0, 255, 255],
+    'azure' => [0, 128, 255],
+    'blue' => [0, 0, 255],
+
+    'brackethighlighter.angle' => [hexdec("58"), hexdec("60"), hexdec("69")],
+    'brackethighlighter.curly' => [hexdec("58"), hexdec("60"), hexdec("69")],
+    'brackethighlighter.quote' => [hexdec("58"), hexdec("60"), hexdec("69")],
+    'brackethighlighter.round' => [hexdec("58"), hexdec("60"), hexdec("69")],
+    'brackethighlighter.square' => [hexdec("58"), hexdec("60"), hexdec("69")],
+    'brackethighlighter.tag' => [hexdec("58"), hexdec("60"), hexdec("69")],
+    'brackethighlighter.unmatched' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'carriage-return' => [hexdec("FA"), hexdec("FB"), hexdec("FC")],
+    'comment' => [hexdec("6A"), hexdec("73"), hexdec("7D")],
+    'constant' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'constant.character.escape' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'constant.other.reference.link' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'entity' => [hexdec("6F"), hexdec("42"), hexdec("C1")],
+    'entity.name' => [hexdec("6F"), hexdec("42"), hexdec("C1")],
+    'entity.name.constant' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'entity.name.tag' => [hexdec("22"), hexdec("86"), hexdec("3A")],
+    'invalid.broken' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'invalid.deprecated' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'invalid.illegal' => [hexdec("FA"), hexdec("FB"), hexdec("FC")],
+    'invalid.unimplemented' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'keyword' => [hexdec("D7"), hexdec("3A"), hexdec("49")],
+    'markup.bold' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'markup.changed' => [hexdec("E3"), hexdec("62"), hexdec("09")],
+    'markup.deleted' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'markup.heading' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'markup.ignored' => [hexdec("F6"), hexdec("F8"), hexdec("FA")],
+    'markup.inserted' => [hexdec("22"), hexdec("86"), hexdec("3A")],
+    'markup.italic' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'markup.list' => [hexdec("73"), hexdec("5C"), hexdec("0F")],
+    'markup.quote' => [hexdec("22"), hexdec("86"), hexdec("3A")],
+    'markup.raw' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'markup.untracked' => [hexdec("F6"), hexdec("F8"), hexdec("FA")],
+    'message.error' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'meta.diff.header' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'meta.diff.header.from-file' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'meta.diff.header.to-file' => [hexdec("22"), hexdec("86"), hexdec("3A")],
+    'meta.diff.range' => [hexdec("6F"), hexdec("42"), hexdec("C1")],
+    'meta.module-reference' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'meta.output' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'meta.property-name' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'meta.separator' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'punctuation.definition.changed' => [hexdec("E3"), hexdec("62"), hexdec("09")],
+    'punctuation.definition.comment' => [hexdec("6A"), hexdec("73"), hexdec("7D")],
+    'punctuation.definition.deleted' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'punctuation.definition.inserted' => [hexdec("22"), hexdec("86"), hexdec("3A")],
+    'punctuation.definition.string' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'punctuation.section.embedded' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'source' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'source.regexp' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'source.ruby.embedded' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'storage' => [hexdec("D7"), hexdec("3A"), hexdec("49")],
+    'storage.modifier.import' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'storage.modifier.package' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'storage.type' => [hexdec("D7"), hexdec("3A"), hexdec("49")],
+    'storage.type.java' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'string' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'string.comment' => [hexdec("6A"), hexdec("73"), hexdec("7D")],
+    'string.other.link' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'string.regexp' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'string.regexp.arbitrary-repitition' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'string.regexp.character-class' => [hexdec("03"), hexdec("2F"), hexdec("62")],
+    'sublimelinter.gutter-mark' => [hexdec("95"), hexdec("9D"), hexdec("A5")],
+    'sublimelinter.mark.error' => [hexdec("B3"), hexdec("1D"), hexdec("28")],
+    'sublimelinter.mark.warning' => [hexdec("E3"), hexdec("62"), hexdec("09")],
+    'support' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'support.constant' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'support.variable' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'variable' => [hexdec("E3"), hexdec("62"), hexdec("09")],
+    'variable.language' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'variable.other' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+    'variable.other.constant' => [hexdec("00"), hexdec("5C"), hexdec("C5")],
+    'variable.parameter.function' => [hexdec("24"), hexdec("29"), hexdec("2E")],
+  ];
+
+  foreach ($basic_colors as $color_name => $color_rgb) {
+    $basic_colors[$color_name] = distance_3d($rgb, $color_rgb);
+  }
+  asort($basic_colors);
+  foreach ($basic_colors as $color_name => $color_rgb) {
+    echo "<p>$color_name: " . $color_rgb . "</p>";
+  }
+
+} else {
+?>
+
+<form action="colors.php" method="post">
+<p>Hex code: <input type="text" name="hexcode" /><br />
+<p><input type="submit" value="Find Scope"></p>
+</form>
+
+<?php
+
+}

--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -6,14 +6,14 @@ uuid: 47CB09FD-7F85-4CCD-96A8-3931CEBFE553
 
 # Igor Pro color mapping:
 #   * Text                  (black)   #000000 → source
-#   * Keyword               (blue)    #0000FF → keyword
-#   * Comment               (red)     #FF0000 → message.error
+#   * Keyword               (blue)    #0000FF → constant
+#   * Comment               (red)     #FF0000 → keyword
 #   * String                (green)   #009C00 → string
 #   * Operation             (dgreen)  #007575 → entity.name.tag
 #   * Built-in Function     (orange)  #C34E00 → variable
 #   * User-defined Function (purple)  #9C00FD → entity.name
 #   * #keywords             (pink)    #CC00A3 → entity.name
-#   * MatrixOP/APMath       (lpurple) #8080FF → entity.name.constant
+#   * MatrixOP/APMath       (lpurple) #8080FF → constant
 #   * Text highlight
 #     - highlight color     (yellow)  #FFFF00 → sublimelinter.mark.warning
 #     - outline color:      (red)     #FF0000 → sublimelinter.mark.error
@@ -25,12 +25,12 @@ patterns:
   comment: Structure definitions
   begin: (?i)^\s*(?:(static)\s+)?(Structure)\b\s*(\w)
   beginCaptures:
-    '1': {name: entity.name.constant.igor} # storage.modifier.static.igor
-    '2': {name: entity.name.constant.igor} # support.type.igor
+    '1': {name: constant.igor} # storage.modifier.static.igor
+    '2': {name: constant.igor} # support.type.igor
     '3': {name: source.igor} # entity.name.type.igor
   end: (?i)^\s*(EndStructure)\b
   endCaptures:
-    '1': {name: entity.name.constant.igor}
+    '1': {name: constant.igor}
   patterns:
   - include: '#igor_variable'
 
@@ -38,9 +38,9 @@ patterns:
   comment: User-defined functions in procedures
   begin: (?i)^\s*(?:(threadsafe)\s+)?(?:(static)\s+)?\s*(Function)\s*(\/\w+)?\s+(\w+)\s*(\()
   beginCaptures:
-    '1': {name: keyword.other.igor}
-    '2': {name: keyword.igor} # storage.modifier.static.igor
-    '3': {name: keyword.igor} # entity.name.type.igor
+    '1': {name: constant.igor}
+    '2': {name: constant.igor} # storage.modifier.static.igor
+    '3': {name: constant.igor} # entity.name.type.igor
     '4': {name: source.igor} # storage.type.function.igor
     '5': {name: entity.name.igor} # entity.name.function.igor
     '6': {name: brackethighlighter.round.igor} # punctuation.definition.parameters.igor
@@ -52,7 +52,7 @@ patterns:
 
 - include: '#igor_variable'
 
-- name: keyword.control.igor
+- name: constant.igor
   match: \b(?i)(?:if|while|for|switch|strswitch|return|do|end|else|elseif|endif|endfor|endswitch|while|menu|submenu|endmenu|case|break|try|catch|endtry|default|continue|Multithread)\b
 
 - name: source.igor # support.variable.igor
@@ -87,7 +87,7 @@ patterns:
 
 - include: '#igor_operations'
 
-- name: storage.type.igor
+- name: constant.igor # storage.type.igor
   comment: inline wave assignments
   match: (?i)\/wave(?=\=)
 
@@ -102,7 +102,7 @@ repository:
       - include: '#constant_punctuation'
       - include: '#constant_numeric'
       - name: entity.name.igor # meta.function-call.igor
-        match: \w+(?=[\(])
+        match: \w+(?:\#\w+)(?=[\(])
 
   constant_punctuation:
     comment: punctuations and operators
@@ -125,21 +125,21 @@ repository:
   constant_numeric:
     comment: numeric constants
     patterns:
-    - name: constant.other.igor # constant.numeric.igor
+    - name: source.igor # constant.numeric.igor
       match: (0x[a-f0-9]+)
-    - name: constant.other.igor # constant.numeric.integer.igor
+    - name: source.igor # constant.numeric.integer.igor
       match: ([\d]+)
-    - name: constant.other.igor # constant.numeric.float.igor
+    - name: source.igor # constant.numeric.float.igor
       match: (\d+\.\d+(e[\+\-]?\d+)?)
 
   igor_variable:
     comment: Igor types
     patterns:
-    - name: keyword.igor # storage.type.igor
-      begin: (?i)^\s*(?:(static)\s+)?\b(variable|string|wave|strconstant|constant|nvar|svar|dfref|funcref|struct|char|uchar|int16|uint16|int32|uint32|int64|uint64|float|double)\s*(\/\w+)?\b
+    - begin: (?i)^\s*(?:(static)\s+)?\b(variable|string|wave|strconstant|constant|nvar|svar|dfref|funcref|struct|char|uchar|int16|uint16|int32|uint32|int64|uint64|float|double)\s*(\/\w+)?\b
       beginCaptures:
-        '1': {name: keyword.igor} # storage.modifier.static.igor
-        '3': {name: keyword.igor} # storage.modifier.igor
+        '1': {name: constant.igor} # storage.modifier.static.igor
+        '2': {name: constant.igor} # storage.type.igor
+        '3': {name: source.igor} # storage.modifier.igor
       end: (=)|$
       endCaptures:
         '1': {name: source.igor} # keyword.operator.assignment.igor
@@ -162,17 +162,17 @@ repository:
       - include: '#igor_variable'
 
   igor_matrixop:
-    name: entity.name.constant.igor # support.other.igor
+    name: constant.igor # support.other.igor
     comment: MatrixOP functions
     match: (?i)\b(?:abs|acos|acosh|asin|asinh|asynccorrelation|atan|atan2|atanh|averageCols|axisToQuat|backwardSub|beam|bitAnd|bitNot|bitOr|bitShift|bitXor|catCols|catRows|cbrt|ceil|chirpz|chirpzf|chol|chunk|clip|cmplx|col|colRepeat|conj|Const|convolve|correlate|cos|cosh|covariance|crosscovar|Det|diagonal|diagrc|e|equal|erf|erfc|exp|fct|fft|floor|forwardSub|fp32|fp64|frobenius|fsct|fsct2|fsst|fsst2|fst|getDiag|greater|hypot|identity|ifft|imag|imageRestore|indexChunks|indexCols|indexLayers|indexRows|INF|insertMat|int16|int32|int8|Integrate|intMatrix|inv|InverseErf|InverseErfc|layer|limitProduct|ln|log|mag|magsqr|matrixToQuat|maxAB|maxCols|maxRows|maxVal|mean|MeanCols|minCols|minRows|minVal|mod|nan|normalize|normalizecols|normalizerows|numCols|numPoints|numRows|numType|outerProduct|p2rect|phase|pi|powc|powr|productCol|productCols|productDiagonal|productRow|productRows|quat|quatToAxis|quatToEuler|quatToMatrix|r2polar|real|rec|redimension|replace|replacenans|reverseCol|reverseCols|reverseRow|reverseRows|rotateChunks|rotateCols|rotateLayers|rotateRows|round|row|rowRepeat|scale|scaleCols|scaleRows|setCol|setNaNs|setOffDiag|setRow|sgn|shiftvector|sin|sinh|slerp|sqrt|subrange|subtractmean|subWaveC|subWaveR|sum|sumBeams|sumcols|sumRows|sumsqr|synccorrelation|tan|tanh|tensorProduct|Trace|transposeVol|tridiag|uint16|uint32|uint8|varcols|vwl|waveChunks|waveIndexSet|waveLayers|wavemap|wavemap2|wavePoints|within|ZeroMat)\b
 
   igor_apmath:
-    name: entity.name.constant.igor # support.other.igor
+    name: constant.igor # support.other.igor
     comment: APMath functions
     match: (?i)\b(?:sqrt|cbrt|sin|cos|tan|asin|acos|atan|atan2|log|log10|exp|pow|sinh|cosh|tanh|asinh|acosh|atanh|factorial|pi|nan|sgn|floor|ceil|gcd|lcd|comp|sum|mean|variance|skew|kurtosis)\b
 
   igor_comment:
-    name: message.error.igor # comment.double-slash.igor
+    name: keyword.igor # comment.double-slash.igor
     comment: double slash comments with doxygen instruction
     begin: //
     end: $
@@ -191,9 +191,10 @@ repository:
 
   igor_operations:
     comment: Operations built into Igor
-    name: entity.name.tag # support.class.igor
-    begin: (?i)\b(?:Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b
+    begin: (?i)\b(Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b
     end: \s(?![\/])|$
+    captures:
+      '1': {name: entity.name.tag.igor} # support.function.igor
     patterns:
     - name: source.igor # support.class.modifier.igor
       comment: operation flags

--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -115,7 +115,7 @@ repository:
         match: ([{}()\[\]])
 
   constant_string:
-    name: entity.name.tag # string.quoted.double.igor
+    name: entity.name.tag.igor # string.quoted.double.igor
     begin: '"'
     end: '"'
     patterns:

--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -8,7 +8,7 @@ uuid: 47CB09FD-7F85-4CCD-96A8-3931CEBFE553
 #   * Text                  (black)   #000000 → source
 #   * Keyword               (blue)    #0000FF → constant
 #   * Comment               (red)     #FF0000 → keyword
-#   * String                (green)   #009C00 → string
+#   * String                (green)   #009C00 → entity.name.tag
 #   * Operation             (dgreen)  #007575 → entity.name.tag
 #   * Built-in Function     (orange)  #C34E00 → variable
 #   * User-defined Function (purple)  #9C00FD → entity.name
@@ -115,7 +115,7 @@ repository:
         match: ([{}()\[\]])
 
   constant_string:
-    name: string.quoted.double.igor
+    name: entity.name.tag # string.quoted.double.igor
     begin: '"'
     end: '"'
     patterns:

--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -85,27 +85,29 @@ patterns:
     - include: '#igor_apmath'
     - include: '#igor_common'
 
-- include: '#igor_basic'
+- include: '#igor_operations'
+
+- name: constant.igor # storage.type.igor
+  comment: inline wave assignments
+  match: (?i)\/wave(?=\=)
+
+- include: '#igor_functions'
+- include: '#igor_common'
 
 repository:
-  igor_basic:
-    comment: all basic syntax that can exist in functions and macros
-    patterns:
-      - include: '#igor_operations'
-      - name: constant.igor # storage.type.igor
-        comment: inline wave assignments
-        match: (?i)\/wave(?=\=)
-      - include: '#igor_functions'
-      - include: '#igor_common'
-
   igor_common:
     comment: common igor pro syntax collection
     patterns:
       - include: '#constant_string'
       - include: '#constant_punctuation'
       - include: '#constant_numeric'
-      - name: entity.name.igor # meta.function-call.igor
-        match: \w+(?:\#\w+)(?=[\(])
+      - include: '#user_functions'
+
+  user_functions:
+    comment: user functions are optionally highlighted in IP8
+    patterns:
+    - name: entity.name.igor # meta.function-call.igor
+      match: ([\w\#]+)(?=[\(])
 
   constant_punctuation:
     comment: punctuations and operators
@@ -185,7 +187,8 @@ repository:
       - begin: \`
         end: \`
         patterns:
-        - include: '#igor_basic'
+        - include: '#igor_functions'
+        - include: '#igor_common'
 
   igor_functions:
     comment: Functions defined in Igor
@@ -195,7 +198,7 @@ repository:
   igor_operations:
     comment: Operations built into Igor
     begin: (?i)\b(Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b
-    end: \s(?![\/])|\s
+    end: \s(?![\/])|$
     captures:
       '1': {name: entity.name.tag.igor} # support.function.igor
     patterns:
@@ -203,6 +206,8 @@ repository:
       comment: operation flags
       begin: \/[A-Za-z]+
       end: (?=\/|\s|=|\")
+    - include: '#igor_functions'
+    - include: '#igor_common'
 
 foldingStartMarker: ^\s*(?i:function|for|if|switch|strswitch|do|try|menu|submenu)\b
 foldingStopMarker: ^\s*(?i:end|endfor|endif|endswitch|while|endtry)\b

--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -85,16 +85,19 @@ patterns:
     - include: '#igor_apmath'
     - include: '#igor_common'
 
-- include: '#igor_operations'
-
-- name: constant.igor # storage.type.igor
-  comment: inline wave assignments
-  match: (?i)\/wave(?=\=)
-
-- include: '#igor_functions'
-- include: '#igor_common'
+- include: '#igor_basic'
 
 repository:
+  igor_basic:
+    comment: all basic syntax that can exist in functions and macros
+    patterns:
+      - include: '#igor_operations'
+      - name: constant.igor # storage.type.igor
+        comment: inline wave assignments
+        match: (?i)\/wave(?=\=)
+      - include: '#igor_functions'
+      - include: '#igor_common'
+
   igor_common:
     comment: common igor pro syntax collection
     patterns:
@@ -182,7 +185,7 @@ repository:
       - begin: \`
         end: \`
         patterns:
-        - include: '#igor_common'
+        - include: '#igor_basic'
 
   igor_functions:
     comment: Functions defined in Igor
@@ -192,7 +195,7 @@ repository:
   igor_operations:
     comment: Operations built into Igor
     begin: (?i)\b(Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b
-    end: \s(?![\/])|$
+    end: \s(?![\/])|\s
     captures:
       '1': {name: entity.name.tag.igor} # support.function.igor
     patterns:
@@ -200,8 +203,6 @@ repository:
       comment: operation flags
       begin: \/[A-Za-z]+
       end: (?=\/|\s|=|\")
-    - include: '#igor_functions'
-    - include: '#igor_common'
 
 foldingStartMarker: ^\s*(?i:function|for|if|switch|strswitch|do|try|menu|submenu)\b
 foldingStopMarker: ^\s*(?i:end|endfor|endif|endswitch|while|endtry)\b

--- a/igorpro.YAML-tmLanguage
+++ b/igorpro.YAML-tmLanguage
@@ -4,6 +4,20 @@ scopeName: source.igor
 fileTypes: [ipf]
 uuid: 47CB09FD-7F85-4CCD-96A8-3931CEBFE553
 
+# Igor Pro color mapping:
+#   * Text                  (black)   #000000 → source
+#   * Keyword               (blue)    #0000FF → keyword
+#   * Comment               (red)     #FF0000 → message.error
+#   * String                (green)   #009C00 → string
+#   * Operation             (dgreen)  #007575 → entity.name.tag
+#   * Built-in Function     (orange)  #C34E00 → variable
+#   * User-defined Function (purple)  #9C00FD → entity.name
+#   * #keywords             (pink)    #CC00A3 → entity.name
+#   * MatrixOP/APMath       (lpurple) #8080FF → entity.name.constant
+#   * Text highlight
+#     - highlight color     (yellow)  #FFFF00 → sublimelinter.mark.warning
+#     - outline color:      (red)     #FF0000 → sublimelinter.mark.error
+
 patterns:
 - include: '#igor_comment'
 
@@ -11,12 +25,12 @@ patterns:
   comment: Structure definitions
   begin: (?i)^\s*(?:(static)\s+)?(Structure)\b\s*(\w)
   beginCaptures:
-    '1': {name: storage.modifier.static.igor}
-    '2': {name: support.type.igor}
-    '3': {name: entity.name.type.igor}
+    '1': {name: entity.name.constant.igor} # storage.modifier.static.igor
+    '2': {name: entity.name.constant.igor} # support.type.igor
+    '3': {name: source.igor} # entity.name.type.igor
   end: (?i)^\s*(EndStructure)\b
   endCaptures:
-    '1': {name: support.type.igor}
+    '1': {name: entity.name.constant.igor}
   patterns:
   - include: '#igor_variable'
 
@@ -25,14 +39,14 @@ patterns:
   begin: (?i)^\s*(?:(threadsafe)\s+)?(?:(static)\s+)?\s*(Function)\s*(\/\w+)?\s+(\w+)\s*(\()
   beginCaptures:
     '1': {name: keyword.other.igor}
-    '2': {name: storage.modifier.static.igor}
-    '3': {name: entity.name.type.igor}
-    '4': {name: storage.type.function.igor}
-    '5': {name: entity.name.function.igor}
-    '6': {name: punctuation.definition.parameters.igor}
+    '2': {name: keyword.igor} # storage.modifier.static.igor
+    '3': {name: keyword.igor} # entity.name.type.igor
+    '4': {name: source.igor} # storage.type.function.igor
+    '5': {name: entity.name.igor} # entity.name.function.igor
+    '6': {name: brackethighlighter.round.igor} # punctuation.definition.parameters.igor
   end: \)
   endCaptures:
-    '0': {name: punctuation.definition.parameters.igor}
+    '0': {name: brackethighlighter.round.igor} # punctuation.definition.parameters.igor
   patterns:
   - include: '#igor_function_definition'
 
@@ -41,21 +55,22 @@ patterns:
 - name: keyword.control.igor
   match: \b(?i)(?:if|while|for|switch|strswitch|return|do|end|else|elseif|endif|endfor|endswitch|while|menu|submenu|endmenu|case|break|try|catch|endtry|default|continue|Multithread)\b
 
-- name: support.variable.igor
+- name: source.igor # support.variable.igor
   comment: auto variables from operations like V_flag, S_names etc.
   match: (?i)\b(?:V|S)_[A-Z]+\b
 
-- name: meta.preprocessor.igor
+- name: entity.name.igor # meta.preprocessor.igor
   comment: typical igor include statements
   begin: '^#include\b'
   end: $
   patterns:
     - include: '#constant_string'
-    - name: string.other.igor
+    - name: source.igor # string.other.igor
       begin: <
       end: \>
+    - include: '#igor_comment'
 
-- name: meta.preprocessor.igor
+- name: entity.name.igor # meta.preprocessor.igor
   comment: C precompiler statements
   match: '^#\w+'
 
@@ -63,7 +78,7 @@ patterns:
   begin: (?i)(MatrixOP|ApMath)
   end: $
   captures:
-    '1': {name: support.function.igor}
+    '1': {name: entity.name.tag.igor} # support.function.igor
   patterns:
     - include: '#igor_comment'
     - include: '#igor_matrixop'
@@ -79,7 +94,6 @@ patterns:
 - include: '#igor_functions'
 - include: '#igor_common'
 
-
 repository:
   igor_common:
     comment: common igor pro syntax collection
@@ -87,16 +101,18 @@ repository:
       - include: '#constant_string'
       - include: '#constant_punctuation'
       - include: '#constant_numeric'
-      - name: meta.function-call.igor
+      - name: entity.name.igor # meta.function-call.igor
         match: \w+(?=[\(])
 
   constant_punctuation:
     comment: punctuations and operators
     patterns:
-      - name: keyword.operator.igor
+      - name: source.igor # keyword.operator.igor
         match: ([\#$~!%^&*+=\|?:<>/-])
-      - name: punctuation.igor
-        match: ([{}()\[\],.;])
+      - name: source.igor # punctuation.igor
+        match: ([,.;])
+      - name: brackethighlighter.tag # punctuation.igor
+        match: ([{}()\[\]])
 
   constant_string:
     name: string.quoted.double.igor
@@ -109,59 +125,59 @@ repository:
   constant_numeric:
     comment: numeric constants
     patterns:
-    - name: constant.numeric.igor
+    - name: constant.other.igor # constant.numeric.igor
       match: (0x[a-f0-9]+)
-    - name: constant.numeric.integer.igor
+    - name: constant.other.igor # constant.numeric.integer.igor
       match: ([\d]+)
-    - name: constant.numeric.float.igor
+    - name: constant.other.igor # constant.numeric.float.igor
       match: (\d+\.\d+(e[\+\-]?\d+)?)
 
   igor_variable:
     comment: Igor types
     patterns:
-    - name: storage.type.igor
+    - name: keyword.igor # storage.type.igor
       begin: (?i)^\s*(?:(static)\s+)?\b(variable|string|wave|strconstant|constant|nvar|svar|dfref|funcref|struct|char|uchar|int16|uint16|int32|uint32|int64|uint64|float|double)\s*(\/\w+)?\b
       beginCaptures:
-        '1': {name: storage.modifier.static.igor}
-        '3': {name: storage.modifier.igor}
+        '1': {name: keyword.igor} # storage.modifier.static.igor
+        '3': {name: keyword.igor} # storage.modifier.igor
       end: (=)|$
       endCaptures:
-        '1': {name: keyword.operator.assignment.igor}
+        '1': {name: source.igor} # keyword.operator.assignment.igor
       patterns:
       - include: '#igor_comment'
-      - name: punctuation.separator.variable.igor
+      - name: source.igor # punctuation.separator.variable.igor
         match: ","
-      - name: variable.igor
+      - name: source.igor # variable.igor
         match: \w
 
   igor_function_definition:
     patterns:
     - include: '#igor_variable'
-    - name: variable.parameter.optional.igor
+    - name: source.igor # variable.parameter.optional.igor
       begin: (\[)
       end: (\])
       captures:
-        '1': {name: punctuation.separator.igor}
+        '1': {name: brackethighlighter.square.igor} # punctuation.separator.igor
       patterns:
       - include: '#igor_variable'
 
   igor_matrixop:
-    name: support.other.igor
+    name: entity.name.constant.igor # support.other.igor
     comment: MatrixOP functions
     match: (?i)\b(?:abs|acos|acosh|asin|asinh|asynccorrelation|atan|atan2|atanh|averageCols|axisToQuat|backwardSub|beam|bitAnd|bitNot|bitOr|bitShift|bitXor|catCols|catRows|cbrt|ceil|chirpz|chirpzf|chol|chunk|clip|cmplx|col|colRepeat|conj|Const|convolve|correlate|cos|cosh|covariance|crosscovar|Det|diagonal|diagrc|e|equal|erf|erfc|exp|fct|fft|floor|forwardSub|fp32|fp64|frobenius|fsct|fsct2|fsst|fsst2|fst|getDiag|greater|hypot|identity|ifft|imag|imageRestore|indexChunks|indexCols|indexLayers|indexRows|INF|insertMat|int16|int32|int8|Integrate|intMatrix|inv|InverseErf|InverseErfc|layer|limitProduct|ln|log|mag|magsqr|matrixToQuat|maxAB|maxCols|maxRows|maxVal|mean|MeanCols|minCols|minRows|minVal|mod|nan|normalize|normalizecols|normalizerows|numCols|numPoints|numRows|numType|outerProduct|p2rect|phase|pi|powc|powr|productCol|productCols|productDiagonal|productRow|productRows|quat|quatToAxis|quatToEuler|quatToMatrix|r2polar|real|rec|redimension|replace|replacenans|reverseCol|reverseCols|reverseRow|reverseRows|rotateChunks|rotateCols|rotateLayers|rotateRows|round|row|rowRepeat|scale|scaleCols|scaleRows|setCol|setNaNs|setOffDiag|setRow|sgn|shiftvector|sin|sinh|slerp|sqrt|subrange|subtractmean|subWaveC|subWaveR|sum|sumBeams|sumcols|sumRows|sumsqr|synccorrelation|tan|tanh|tensorProduct|Trace|transposeVol|tridiag|uint16|uint32|uint8|varcols|vwl|waveChunks|waveIndexSet|waveLayers|wavemap|wavemap2|wavePoints|within|ZeroMat)\b
 
   igor_apmath:
-    name: support.other.igor
+    name: entity.name.constant.igor # support.other.igor
     comment: APMath functions
     match: (?i)\b(?:sqrt|cbrt|sin|cos|tan|asin|acos|atan|atan2|log|log10|exp|pow|sinh|cosh|tanh|asinh|acosh|atanh|factorial|pi|nan|sgn|floor|ceil|gcd|lcd|comp|sum|mean|variance|skew|kurtosis)\b
 
   igor_comment:
-    name: comment.double-slash.igor
+    name: message.error.igor # comment.double-slash.igor
     comment: double slash comments with doxygen instruction
     begin: //
     end: $
     patterns:
-      - name: keyword.other.igor
+      - name: comment.igor # keyword.other.igor
         match: \s\@\w+(?:\[\w+\])?
       - begin: \`
         end: \`
@@ -170,16 +186,16 @@ repository:
 
   igor_functions:
     comment: Functions defined in Igor
-    name: support.function.igor
+    name: variable.igor # support.function.igor
     match: (?i)\b(?:AddListItem|AiryA|AiryAD|AiryB|AiryBD|AnnotationInfo|AnnotationList|AxisInfo|AxisList|AxisValFromPixel|AxonTelegraphAGetDataNum|AxonTelegraphAGetDataString|AxonTelegraphAGetDataStruct|AxonTelegraphGetDataNum|AxonTelegraphGetDataString|AxonTelegraphGetDataStruct|AxonTelegraphGetTimeoutMs|AxonTelegraphSetTimeoutMs|Base64Decode|Base64Encode|Besseli|Besselj|Besselk|Bessely|BinarySearch|BinarySearchInterp|CTabList|CaptureHistory|CaptureHistoryStart|CheckName|ChildWindowList|CleanupName|ContourInfo|ContourNameList|ContourNameToWaveRef|ContourZ|ControlNameList|ConvertTextEncoding|CountObjects|CountObjectsDFR|CreationDate|CsrInfo|CsrWave|CsrWaveRef|CsrXWave|CsrXWaveRef|DataFolderDir|DataFolderExists|DataFolderRefStatus|DataFolderRefsEqual|DateToJulian|Dawson|DimDelta|DimOffset|DimSize|Faddeeva|FetchURL|FindDimLabel|FindListItem|FontList|FontSizeHeight|FontSizeStringWidth|FresnelCos|FresnelSin|FuncRefInfo|FunctionInfo|FunctionList|FunctionPath|GISGetAllFileFormats|GISSRefsAreEqual|Gauss|Gauss1D|Gauss2D|GetBrowserLine|GetBrowserSelection|GetDataFolder|GetDataFolderDFR|GetDefaultFont|GetDefaultFontSize|GetDefaultFontStyle|GetDimLabel|GetEnvironmentVariable|GetErrMessage|GetFormula|GetIndependentModuleName|GetIndexedObjName|GetIndexedObjNameDFR|GetKeyState|GetRTErrMessage|GetRTError|GetRTLocInfo|GetRTLocation|GetRTStackInfo|GetScrapText|GetUserData|GetWavesDataFolder|GetWavesDataFolderDFR|GizmoInfo|GizmoScale|GrepList|GrepString|GuideInfo|GuideNameList|HDF5AttributeInfo|HDF5DatasetInfo|HDF5LibraryInfo|HDF5TypeInfo|Hash|HyperG0F1|HyperG1F1|HyperG2F1|HyperGNoise|HyperGPFQ|IgorInfo|IgorVersion|ImageInfo|ImageNameList|ImageNameToWaveRef|IndependentModuleList|IndexToScale|IndexedDir|IndexedFile|Inf|Integrate1D|Interp2D|Interp3D|ItemsInList|JacobiCn|JacobiSn|JSON_CreateStructured|JSON_Kill|JSON_GetType|JSON_GetArraySize|JSON_GetMaxArraySize|JSON_Parse|JSON_Dump|JulianToDate|Laguerre|LaguerreA|LaguerreGauss|LambertW|LayoutInfo|LegendreA|ListMatch|ListToTextWave|ListToWaveRefWave|LowerStr|MCC_AutoBridgeBal|MCC_AutoFastComp|MCC_AutoPipetteOffset|MCC_AutoSlowComp|MCC_AutoWholeCellComp|MCC_GetBridgeBalEnable|MCC_GetBridgeBalResist|MCC_GetFastCompCap|MCC_GetFastCompTau|MCC_GetHolding|MCC_GetHoldingEnable|MCC_GetMode|MCC_GetNeutralizationCap|MCC_GetNeutralizationEnable|MCC_GetOscKillerEnable|MCC_GetPipetteOffset|MCC_GetPrimarySignalGain|MCC_GetPrimarySignalHPF|MCC_GetPrimarySignalLPF|MCC_GetRsCompBandwidth|MCC_GetRsCompCorrection|MCC_GetRsCompEnable|MCC_GetRsCompPrediction|MCC_GetSecondarySignalGain|MCC_GetSecondarySignalLPF|MCC_GetSlowCompCap|MCC_GetSlowCompTau|MCC_GetSlowCompTauX20Enable|MCC_GetSlowCurrentInjEnable|MCC_GetSlowCurrentInjLevel|MCC_GetSlowCurrentInjSetlTime|MCC_GetWholeCellCompCap|MCC_GetWholeCellCompEnable|MCC_GetWholeCellCompResist|MCC_SelectMultiClamp700B|MCC_SetBridgeBalEnable|MCC_SetBridgeBalResist|MCC_SetFastCompCap|MCC_SetFastCompTau|MCC_SetHolding|MCC_SetHoldingEnable|MCC_SetMode|MCC_SetNeutralizationCap|MCC_SetNeutralizationEnable|MCC_SetOscKillerEnable|MCC_SetPipetteOffset|MCC_SetPrimarySignalGain|MCC_SetPrimarySignalHPF|MCC_SetPrimarySignalLPF|MCC_SetRsCompBandwidth|MCC_SetRsCompCorrection|MCC_SetRsCompEnable|MCC_SetRsCompPrediction|MCC_SetSecondarySignalGain|MCC_SetSecondarySignalLPF|MCC_SetSlowCompCap|MCC_SetSlowCompTau|MCC_SetSlowCompTauX20Enable|MCC_SetSlowCurrentInjEnable|MCC_SetSlowCurrentInjLevel|MCC_SetSlowCurrentInjSetlTime|MCC_SetTimeoutMs|MCC_SetWholeCellCompCap|MCC_SetWholeCellCompEnable|MCC_SetWholeCellCompResist|MPFXEMGPeak|MPFXExpConvExpPeak|MPFXGaussPeak|MPFXLorenzianPeak|MPFXVoigtPeak|MacroList|MandelbrotPoint|MarcumQ|MatrixCondition|MatrixDet|MatrixDot|MatrixRank|MatrixTrace|ModDate|NVAR_Exists|NaN|NameOfWave|NewFreeDataFolder|NewFreeWave|NormalizeUnicode|NumVarOrDefault|NumberByKey|OperationList|PICTInfo|PICTList|PadString|PanelResolution|ParamIsDefault|ParseFilePath|PathList|Pi|PixelFromAxisVal|PolygonArea|PossiblyQuoteName|ProcedureText|RemoveByKey|RemoveEnding|RemoveFromList|RemoveListItem|ReplaceNumberByKey|ReplaceString|ReplaceStringByKey|SQL2DBinaryWaveToTextWave|SQLAllocHandle|SQLAllocStmt|SQLBinaryWavesToTextWave|SQLBindCol|SQLBindParameter|SQLBrowseConnect|SQLBulkOperations|SQLCancel|SQLCloseCursor|SQLColAttributeNum|SQLColAttributeStr|SQLColumnPrivileges|SQLColumns|SQLConnect|SQLDataSources|SQLDescribeCol|SQLDescribeParam|SQLDisconnect|SQLDriverConnect|SQLDrivers|SQLEndTran|SQLError|SQLExecDirect|SQLExecute|SQLFetch|SQLFetchScroll|SQLForeignKeys|SQLFreeConnect|SQLFreeEnv|SQLFreeHandle|SQLFreeStmt|SQLGetConnectAttrNum|SQLGetConnectAttrStr|SQLGetCursorName|SQLGetDataNum|SQLGetDataStr|SQLGetDescFieldNum|SQLGetDescFieldStr|SQLGetDescRec|SQLGetDiagFieldNum|SQLGetDiagFieldStr|SQLGetDiagRec|SQLGetEnvAttrNum|SQLGetEnvAttrStr|SQLGetFunctions|SQLGetInfoNum|SQLGetInfoStr|SQLGetStmtAttrNum|SQLGetStmtAttrStr|SQLGetTypeInfo|SQLMoreResults|SQLNativeSql|SQLNumParams|SQLNumResultCols|SQLNumResultRowsIfKnown|SQLNumRowsFetched|SQLParamData|SQLPrepare|SQLPrimaryKeys|SQLProcedureColumns|SQLProcedures|SQLPutData|SQLReinitialize|SQLRowCount|SQLSetConnectAttrNum|SQLSetConnectAttrStr|SQLSetCursorName|SQLSetDescFieldNum|SQLSetDescFieldStr|SQLSetDescRec|SQLSetEnvAttrNum|SQLSetEnvAttrStr|SQLSetPos|SQLSetStmtAttrNum|SQLSetStmtAttrStr|SQLSpecialColumns|SQLStatistics|SQLTablePrivileges|SQLTables|SQLTextWaveTo2DBinaryWave|SQLTextWaveToBinaryWaves|SQLUpdateBoundValues|SQLXOPCheckState|SVAR_Exists|ScreenResolution|Secs2Date|Secs2Time|SelectNumber|SelectString|SetEnvironmentVariable|SortList|SpecialCharacterInfo|SpecialCharacterList|SpecialDirPath|SphericalBessJ|SphericalBessJD|SphericalBessY|SphericalBessYD|SphericalHarmonics|StartMSTimer|StatsBetaCDF|StatsBetaPDF|StatsBinomialCDF|StatsBinomialPDF|StatsCMSSDCDF|StatsCauchyCDF|StatsCauchyPDF|StatsChiCDF|StatsChiPDF|StatsCorrelation|StatsDExpCDF|StatsDExpPDF|StatsEValueCDF|StatsEValuePDF|StatsErlangCDF|StatsErlangPDF|StatsErrorPDF|StatsExpCDF|StatsExpPDF|StatsFCDF|StatsFPDF|StatsFriedmanCDF|StatsGEVCDF|StatsGEVPDF|StatsGammaCDF|StatsGammaPDF|StatsGeometricCDF|StatsGeometricPDF|StatsHyperGCDF|StatsHyperGPDF|StatsInvBetaCDF|StatsInvBinomialCDF|StatsInvCMSSDCDF|StatsInvCauchyCDF|StatsInvChiCDF|StatsInvDExpCDF|StatsInvEValueCDF|StatsInvExpCDF|StatsInvFCDF|StatsInvFriedmanCDF|StatsInvGammaCDF|StatsInvGeometricCDF|StatsInvKuiperCDF|StatsInvLogNormalCDF|StatsInvLogisticCDF|StatsInvMaxwellCDF|StatsInvMooreCDF|StatsInvNBinomialCDF|StatsInvNCChiCDF|StatsInvNCFCDF|StatsInvNormalCDF|StatsInvParetoCDF|StatsInvPoissonCDF|StatsInvPowerCDF|StatsInvQCDF|StatsInvQpCDF|StatsInvRayleighCDF|StatsInvRectangularCDF|StatsInvSpearmanCDF|StatsInvStudentCDF|StatsInvTopDownCDF|StatsInvTriangularCDF|StatsInvUsquaredCDF|StatsInvVonMisesCDF|StatsInvWeibullCDF|StatsKuiperCDF|StatsLogNormalCDF|StatsLogNormalPDF|StatsLogisticCDF|StatsLogisticPDF|StatsMaxwellCDF|StatsMaxwellPDF|StatsMedian|StatsMooreCDF|StatsNBinomialCDF|StatsNBinomialPDF|StatsNCChiCDF|StatsNCChiPDF|StatsNCFCDF|StatsNCFPDF|StatsNCTCDF|StatsNCTPDF|StatsNormalCDF|StatsNormalPDF|StatsParetoCDF|StatsParetoPDF|StatsPermute|StatsPoissonCDF|StatsPoissonPDF|StatsPowerCDF|StatsPowerNoise|StatsPowerPDF|StatsQCDF|StatsQpCDF|StatsRayleighCDF|StatsRayleighPDF|StatsRectangularCDF|StatsRectangularPDF|StatsRunsCDF|StatsSpearmanRhoCDF|StatsStudentCDF|StatsStudentPDF|StatsTopDownCDF|StatsTriangularCDF|StatsTriangularPDF|StatsTrimmedMean|StatsUSquaredCDF|StatsVonMisesCDF|StatsVonMisesNoise|StatsVonMisesPDF|StatsWaldCDF|StatsWaldPDF|StatsWeibullCDF|StatsWeibullPDF|StopMSTimer|StrVarOrDefault|StringByKey|StringFromList|StringList|StudentA|StudentT|TDMAddChannel|TDMAddGroup|TDMAppendDataValues|TDMAppendDataValuesTime|TDMChannelPropertyExists|TDMCloseChannel|TDMCloseFile|TDMCloseGroup|TDMCreateChannelProperty|TDMCreateFile|TDMCreateFileProperty|TDMCreateGroupProperty|TDMFilePropertyExists|TDMGetChannelPropertyNames|TDMGetChannelPropertyNum|TDMGetChannelPropertyStr|TDMGetChannelPropertyTime|TDMGetChannelPropertyType|TDMGetChannelStringPropertyLen|TDMGetChannels|TDMGetDataType|TDMGetDataValues|TDMGetDataValuesTime|TDMGetFilePropertyNames|TDMGetFilePropertyNum|TDMGetFilePropertyStr|TDMGetFilePropertyTime|TDMGetFilePropertyType|TDMGetFileStringPropertyLen|TDMGetGroupPropertyNames|TDMGetGroupPropertyNum|TDMGetGroupPropertyStr|TDMGetGroupPropertyTime|TDMGetGroupPropertyType|TDMGetGroupStringPropertyLen|TDMGetGroups|TDMGetLibraryErrorDescription|TDMGetNumChannelProperties|TDMGetNumChannels|TDMGetNumDataValues|TDMGetNumFileProperties|TDMGetNumGroupProperties|TDMGetNumGroups|TDMGroupPropertyExists|TDMOpenFile|TDMOpenFileEx|TDMRemoveChannel|TDMRemoveGroup|TDMReplaceDataValues|TDMReplaceDataValuesTime|TDMSaveFile|TDMSetChannelPropertyNum|TDMSetChannelPropertyStr|TDMSetChannelPropertyTime|TDMSetDataValues|TDMSetDataValuesTime|TDMSetFilePropertyNum|TDMSetFilePropertyStr|TDMSetFilePropertyTime|TDMSetGroupPropertyNum|TDMSetGroupPropertyStr|TDMSetGroupPropertyTime|TableInfo|TagVal|TagWaveRef|TextEncodingCode|TextEncodingName|TextFile|ThreadGroupCreate|ThreadGroupGetDF|ThreadGroupGetDFR|ThreadGroupRelease|ThreadGroupWait|ThreadProcessorCount|ThreadReturnValue|TraceFromPixel|TraceInfo|TraceNameList|TraceNameToWaveRef|TrimString|URLDecode|URLEncode|UnPadString|UniqueName|UnsetEnvironmentVariable|UpperStr|VariableList|Variance|VoigtFunc|VoigtPeak|WaveCRC|WaveDims|WaveExists|WaveHash|WaveInfo|WaveList|WaveMax|WaveMin|WaveName|WaveRefIndexed|WaveRefIndexedDFR|WaveRefWaveToList|WaveRefsEqual|WaveTextEncoding|WaveType|WaveUnits|WhichListItem|WinList|WinName|WinRecreation|WinType|XWaveName|XWaveRefFromTrace|ZernikeR|abs|acos|acosh|alog|area|areaXY|asin|asinh|atan|atan2|atanh|beta|betai|binomial|binomialNoise|binomialln|cabs|ceil|cequal|char2num|chebyshev|chebyshevU|cmplx|cmpstr|conj|cos|cosIntegral|cosh|cot|coth|cpowi|csc|csch|date|date2secs|datetime|defined|deltax|digamma|dilogarithm|ei|enoise|equalWaves|erf|erfc|erfcw|exists|exp|expInt|expIntegralE1|expNoise|fDAQmx_AI_GetReader|fDAQmx_AO_UpdateOutputs|fDAQmx_CTR_Finished|fDAQmx_CTR_IsFinished|fDAQmx_CTR_IsPulseFinished|fDAQmx_CTR_ReadCounter|fDAQmx_CTR_ReadWithOptions|fDAQmx_CTR_SetPulseFrequency|fDAQmx_CTR_Start|fDAQmx_ConnectTerminals|fDAQmx_DIO_Finished|fDAQmx_DIO_PortWidth|fDAQmx_DIO_Read|fDAQmx_DIO_Write|fDAQmx_DeviceNames|fDAQmx_DisconnectTerminals|fDAQmx_ErrorString|fDAQmx_ExternalCalDate|fDAQmx_NumAnalogInputs|fDAQmx_NumAnalogOutputs|fDAQmx_NumCounters|fDAQmx_NumDIOPorts|fDAQmx_ReadChan|fDAQmx_ReadNamedChan|fDAQmx_ResetDevice|fDAQmx_ScanGetAvailable|fDAQmx_ScanGetNextIndex|fDAQmx_ScanStart|fDAQmx_ScanStop|fDAQmx_ScanWait|fDAQmx_ScanWaitWithTimeout|fDAQmx_SelfCalDate|fDAQmx_SelfCalibration|fDAQmx_WF_IsFinished|fDAQmx_WF_WaitUntilFinished|fDAQmx_WaveformStart|fDAQmx_WaveformStop|fDAQmx_WriteChan|factorial|fakedata|faverage|faverageXY|floor|gamma|gammaEuler|gammaInc|gammaNoise|gammln|gammp|gammq|gcd|gnoise|hcsr|hermite|hermiteGauss|imag|interp|inverseERF|inverseERFC|leftx|limit|ln|log|logNormalNoise|lorentzianNoise|magsqr|max|mean|median|min|mod|norm|note|num2char|num2istr|num2str|numpnts|numtype|p2rect|pcsr|pnt2x|poissonNoise|poly|poly2D|qcsr|r2polar|real|rightx|round|sawtooth|scaleToIndex|sec|sech|sign|sin|sinIntegral|sinc|sinh|sqrt|str2num|stringCRC|stringmatch|strlen|strsearch|sum|tan|tango_close_device|tango_command_inout|tango_compute_image_proj|tango_get_dev_attr_list|tango_get_dev_black_box|tango_get_dev_cmd_list|tango_get_dev_status|tango_get_dev_timeout|tango_get_error_stack|tango_open_device|tango_ping_device|tango_read_attribute|tango_read_attributes|tango_reload_dev_interface|tango_resume_attr_monitor|tango_set_attr_monitor_period|tango_set_dev_timeout|tango_start_attr_monitor|tango_stop_attr_monitor|tango_suspend_attr_monitor|tango_write_attribute|tango_write_attributes|tanh|ticks|time|trunc|vcsr|viAssertIntrSignal|viAssertTrigger|viAssertUtilSignal|viClear|viClose|viDisableEvent|viDiscardEvents|viEnableEvent|viFindNext|viFindRsrc|viGetAttribute|viGetAttributeString|viGpibCommand|viGpibControlATN|viGpibControlREN|viGpibPassControl|viGpibSendIFC|viIn16|viIn32|viIn8|viLock|viMapAddress|viMapTrigger|viMemAlloc|viMemFree|viMoveIn16|viMoveIn32|viMoveIn8|viMoveOut16|viMoveOut32|viMoveOut8|viOpen|viOpenDefaultRM|viOut16|viOut32|viOut8|viPeek16|viPeek32|viPeek8|viPoke16|viPoke32|viPoke8|viRead|viReadSTB|viSetAttribute|viSetAttributeString|viStatusDesc|viTerminate|viUnlock|viUnmapAddress|viUnmapTrigger|viUsbControlIn|viUsbControlOut|viVxiCommandQuery|viWaitOnEvent|viWrite|wnoise|x2pnt|xcsr|zcsr|zeromq_client_connect|zeromq_client_connect|zeromq_client_recv|zeromq_client_recv|zeromq_client_send|zeromq_client_send|zeromq_handler_start|zeromq_handler_start|zeromq_handler_stop|zeromq_handler_stop|zeromq_server_bind|zeromq_server_bind|zeromq_server_recv|zeromq_server_recv|zeromq_server_send|zeromq_server_send|zeromq_set|zeromq_set|zeromq_stop|zeromq_stop|zeromq_test_callfunction|zeromq_test_callfunction|zeromq_test_serializeWave|zeromq_test_serializeWave|zeta)\b
 
   igor_operations:
     comment: Operations built into Igor
-    name: support.class.igor
+    name: entity.name.tag # support.class.igor
     begin: (?i)\b(?:Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b
     end: \s(?![\/])|$
     patterns:
-    - name: support.class.modifier.igor
+    - name: source.igor # support.class.modifier.igor
       comment: operation flags
       begin: \/[A-Za-z]+
       end: (?=\/|\s|=|\")

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -26,12 +26,12 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.constant.igor</string>
+					<string>constant.igor</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.constant.igor</string>
+					<string>constant.igor</string>
 				</dict>
 				<key>3</key>
 				<dict>
@@ -48,7 +48,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.constant.igor</string>
+					<string>constant.igor</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -69,17 +69,17 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.igor</string>
+					<string>constant.igor</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.igor</string>
+					<string>constant.igor</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.igor</string>
+					<string>constant.igor</string>
 				</dict>
 				<key>4</key>
 				<dict>
@@ -127,7 +127,7 @@
 			<key>match</key>
 			<string>\b(?i)(?:if|while|for|switch|strswitch|return|do|end|else|elseif|endif|endfor|endswitch|while|menu|submenu|endmenu|case|break|try|catch|endtry|default|continue|Multithread)\b</string>
 			<key>name</key>
-			<string>keyword.control.igor</string>
+			<string>constant.igor</string>
 		</dict>
 		<dict>
 			<key>comment</key>
@@ -219,7 +219,7 @@
 			<key>match</key>
 			<string>(?i)\/wave(?=\=)</string>
 			<key>name</key>
-			<string>storage.type.igor</string>
+			<string>constant.igor</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -242,19 +242,19 @@
 					<key>match</key>
 					<string>(0x[a-f0-9]+)</string>
 					<key>name</key>
-					<string>constant.other.igor</string>
+					<string>source.igor</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>([\d]+)</string>
 					<key>name</key>
-					<string>constant.other.igor</string>
+					<string>source.igor</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>(\d+\.\d+(e[\+\-]?\d+)?)</string>
 					<key>name</key>
-					<string>constant.other.igor</string>
+					<string>source.igor</string>
 				</dict>
 			</array>
 		</dict>
@@ -309,7 +309,7 @@
 			<key>match</key>
 			<string>(?i)\b(?:sqrt|cbrt|sin|cos|tan|asin|acos|atan|atan2|log|log10|exp|pow|sinh|cosh|tanh|asinh|acosh|atanh|factorial|pi|nan|sgn|floor|ceil|gcd|lcd|comp|sum|mean|variance|skew|kurtosis)\b</string>
 			<key>name</key>
-			<string>entity.name.constant.igor</string>
+			<string>constant.igor</string>
 		</dict>
 		<key>igor_comment</key>
 		<dict>
@@ -320,7 +320,7 @@
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
-			<string>message.error.igor</string>
+			<string>keyword.igor</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -364,7 +364,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\w+(?=[\(])</string>
+					<string>\w+(?:\#\w+)(?=[\(])</string>
 					<key>name</key>
 					<string>entity.name.igor</string>
 				</dict>
@@ -419,18 +419,24 @@
 			<key>match</key>
 			<string>(?i)\b(?:abs|acos|acosh|asin|asinh|asynccorrelation|atan|atan2|atanh|averageCols|axisToQuat|backwardSub|beam|bitAnd|bitNot|bitOr|bitShift|bitXor|catCols|catRows|cbrt|ceil|chirpz|chirpzf|chol|chunk|clip|cmplx|col|colRepeat|conj|Const|convolve|correlate|cos|cosh|covariance|crosscovar|Det|diagonal|diagrc|e|equal|erf|erfc|exp|fct|fft|floor|forwardSub|fp32|fp64|frobenius|fsct|fsct2|fsst|fsst2|fst|getDiag|greater|hypot|identity|ifft|imag|imageRestore|indexChunks|indexCols|indexLayers|indexRows|INF|insertMat|int16|int32|int8|Integrate|intMatrix|inv|InverseErf|InverseErfc|layer|limitProduct|ln|log|mag|magsqr|matrixToQuat|maxAB|maxCols|maxRows|maxVal|mean|MeanCols|minCols|minRows|minVal|mod|nan|normalize|normalizecols|normalizerows|numCols|numPoints|numRows|numType|outerProduct|p2rect|phase|pi|powc|powr|productCol|productCols|productDiagonal|productRow|productRows|quat|quatToAxis|quatToEuler|quatToMatrix|r2polar|real|rec|redimension|replace|replacenans|reverseCol|reverseCols|reverseRow|reverseRows|rotateChunks|rotateCols|rotateLayers|rotateRows|round|row|rowRepeat|scale|scaleCols|scaleRows|setCol|setNaNs|setOffDiag|setRow|sgn|shiftvector|sin|sinh|slerp|sqrt|subrange|subtractmean|subWaveC|subWaveR|sum|sumBeams|sumcols|sumRows|sumsqr|synccorrelation|tan|tanh|tensorProduct|Trace|transposeVol|tridiag|uint16|uint32|uint8|varcols|vwl|waveChunks|waveIndexSet|waveLayers|wavemap|wavemap2|wavePoints|within|ZeroMat)\b</string>
 			<key>name</key>
-			<string>entity.name.constant.igor</string>
+			<string>constant.igor</string>
 		</dict>
 		<key>igor_operations</key>
 		<dict>
 			<key>begin</key>
-			<string>(?i)\b(?:Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b</string>
+			<string>(?i)\b(Abort|AddFIFOData|AddFIFOVectData|AddMovieAudio|AddMovieFrame|AddWavesToBoxPlot|AddWavesToViolinPlot|AdoptFiles|Append|AppendBoxPlot|AppendImage|AppendLayoutObject|AppendMatrixContour|AppendText|AppendToGizmo|AppendToGraph|AppendToLayout|AppendToTable|AppendViolinPlot|AppendXYZContour|AutoPositionWindow|AxonTelegraphFindServers|BackgroundInfo|Beep|BoundingBall|BoxSmooth|BrowseURL|BuildMenu|Button|CWT|Chart|CheckBox|CheckDisplayed|ChooseColor|Close|CloseHelp|CloseMovie|CloseProc|ColorScale|ColorTab2Wave|Concatenate|ControlBar|ControlInfo|ControlUpdate|ConvertGlobalStringTextEncoding|ConvexHull|Convolve|CopyDimLabels|CopyFile|CopyFolder|CopyScales|Correlate|CreateAliasShortcut|CreateBrowser|Cross|CtrlBackground|CtrlFIFO|CtrlNamedBackground|Cursor|CurveFit|CustomControl|DAQmx_AI_SetupReader|DAQmx_AO_SetOutputs|DAQmx_CTR_CountEdges|DAQmx_CTR_OutputPulse|DAQmx_CTR_Period|DAQmx_CTR_PulseWidth|DAQmx_DIO_Config|DAQmx_DIO_WriteNewData|DAQmx_Scan|DAQmx_WaveformGen|DPSS|DSPDetrend|DSPPeriodogram|DWT|Debugger|DebuggerOptions|DefaultFont|DefaultGuiControls|DefaultGuiFont|DefaultTextEncoding|DefineGuide|DelayUpdate|DeleteAnnotations|DeleteFile|DeleteFolder|DeletePoints|Differentiate|Display|DisplayHelpTopic|DisplayProcedure|DoAlert|DoIgorMenu|DoUpdate|DoWindow|DoXOPIdle|DrawAction|DrawArc|DrawBezier|DrawLine|DrawOval|DrawPICT|DrawPoly|DrawRRect|DrawRect|DrawText|DrawUserShape|Duplicate|DuplicateDataFolder|EdgeStats|Edit|ErrorBars|EstimatePeakSizes|Execute|ExecuteScriptText|ExperimentInfo|ExperimentModified|ExportGizmo|Extract|FBinRead|FBinWrite|FFT|FGetPos|FIFO2Wave|FIFOStatus|FMaxFlat|FPClustering|FReadLine|FSetPos|FStatus|FTPCreateDirectory|FTPDelete|FTPDownload|FTPUpload|FastGaussTransform|FastOp|FilterFIR|FilterIIR|FindAPeak|FindContour|FindDuplicates|FindLevel|FindLevels|FindPeak|FindPointsInPoly|FindRoots|FindSequence|FindValue|FuncFit|FuncFitMD|GBLoadWave|GISCreateVectorLayer|GISGetRasterInfo|GISGetRegisteredFileInfo|GISGetVectorLayerInfo|GISLoadRasterData|GISLoadVectorData|GISRasterizeVectorData|GISRegisterFile|GISTransformCoords|GISUnRegisterFile|GISWriteFieldData|GISWriteGeometryData|GISWriteRaster|GPIB2|GPIBRead2|GPIBReadBinary2|GPIBReadBinaryWave2|GPIBReadWave2|GPIBWrite2|GPIBWriteBinary2|GPIBWriteBinaryWave2|GPIBWriteWave2|GetAxis|GetCamera|GetFileFolderInfo|GetGizmo|GetLastUserMenuInfo|GetMarquee|GetMouse|GetSelection|GetWindow|GraphNormal|GraphWaveDraw|GraphWaveEdit|Grep|GroupBox|HDF5CloseFile|HDF5CloseGroup|HDF5ConvertColors|HDF5CreateFile|HDF5CreateGroup|HDF5CreateLink|HDF5Dump|HDF5DumpErrors|HDF5DumpState|HDF5FlushFile|HDF5ListAttributes|HDF5ListGroup|HDF5LoadData|HDF5LoadGroup|HDF5LoadImage|HDF5OpenFile|HDF5OpenGroup|HDF5SaveData|HDF5SaveGroup|HDF5SaveImage|HDF5TestOperation|HDF5UnlinkObject|HDFInfo|HDFReadImage|HDFReadSDS|HDFReadVset|Hanning|HideIgorMenus|HideInfo|HideProcedures|HideTools|HilbertTransform|Histogram|ICA|IFFT|ITCCloseAll2|ITCCloseDevice2|ITCConfigAllChannels2|ITCConfigChannel2|ITCConfigChannelReset2|ITCConfigChannelUpload2|ITCFIFOAvailable2|ITCFIFOAvailableAll2|ITCGetAllChannelsConfig2|ITCGetChannelConfig2|ITCGetCurrentDevice2|ITCGetDeviceInfo2|ITCGetDevices2|ITCGetErrorString2|ITCGetSerialNumber2|ITCGetState2|ITCGetVersions2|ITCInitialize2|ITCOpenDevice2|ITCReadADC2|ITCReadDigital2|ITCReadTimer2|ITCSelectDevice2|ITCSetDAC2|ITCSetGlobals2|ITCSetModes2|ITCSetState2|ITCStartAcq2|ITCStopAcq2|ITCUpdateFIFOPosition2|ITCUpdateFIFOPositionAll2|ITCWriteDigital2|ImageAnalyzeParticles|ImageBlend|ImageBoundaryToMask|ImageComposite|ImageEdgeDetection|ImageFileInfo|ImageFilter|ImageFocus|ImageFromXYZ|ImageGLCM|ImageGenerateROIMask|ImageHistModification|ImageHistogram|ImageInterpolate|ImageLineProfile|ImageLoad|ImageMorphology|ImageRegistration|ImageRemoveBackground|ImageRestore|ImageRotate|ImageSave|ImageSeedFill|ImageSkeleton3d|ImageSnake|ImageStats|ImageThreshold|ImageTransform|ImageUnwrapPhase|ImageWindow|IndexSort|InsertPoints|Integrate|Integrate2D|IntegrateODE|Interp3DPath|Interpolate2|Interpolate3D|JCAMPLoadWave|JointHistogram|JSON_AddValue|JSON_Delete|JSON_GetValue|JSON_GetKeys|JSON_SetArrayElement|KMeans|KillBackground|KillControl|KillDataFolder|KillFIFO|KillFreeAxis|KillPICTs|KillPath|KillStrings|KillVariables|KillWaves|KillWindow|Label|Layout|LayoutPageAction|LayoutSlideShow|Legend|LinearFeedbackShiftRegister|ListBox|LoadData|LoadPICT|LoadPackagePreferences|LoadWave|Loess|LombPeriodogram|MCC_FindServers|MFR_CheckForNewBricklets|MFR_CloseResultFile|MFR_CreateOverviewTable|MFR_GetBrickletCount|MFR_GetBrickletData|MFR_GetBrickletDeployData|MFR_GetBrickletMetaData|MFR_GetBrickletRawData|MFR_GetReportTemplate|MFR_GetResultFileMetaData|MFR_GetResultFileName|MFR_GetVernissageVersion|MFR_GetVersion|MFR_GetXOPErrorMessage|MFR_OpenResultFile|MLLoadWave|Make|MakeIndex|MarkPerfTestTime|MatrixConvolve|MatrixCorr|MatrixEigenV|MatrixFilter|MatrixGLM|MatrixGaussJ|MatrixInverse|MatrixLLS|MatrixLUBkSub|MatrixLUD|MatrixLUDTD|MatrixLinearSolve|MatrixLinearSolveTD|MatrixMultiply|MatrixSVBkSub|MatrixSVD|MatrixSchur|MatrixSolve|MatrixTranspose|MeasureStyledText|Modify|ModifyBoxPlot|ModifyBrowser|ModifyCamera|ModifyContour|ModifyControl|ModifyControlList|ModifyFreeAxis|ModifyGizmo|ModifyGraph|ModifyImage|ModifyLayout|ModifyPanel|ModifyTable|ModifyViolinPlot|ModifyWaterfall|MoveDataFolder|MoveFile|MoveFolder|MoveString|MoveSubwindow|MoveVariable|MoveWave|MoveWindow|MultiTaperPSD|MultiThreadingControl|NC_CloseFile|NC_DumpErrors|NC_Inquire|NC_ListAttributes|NC_ListObjects|NC_LoadData|NC_OpenFile|NI4882|NILoadWave|NeuralNetworkRun|NeuralNetworkTrain|NewCamera|NewDataFolder|NewFIFO|NewFIFOChan|NewFreeAxis|NewGizmo|NewImage|NewLayout|NewMovie|NewNotebook|NewPanel|NewPath|NewWaterfall|Note|Notebook|NotebookAction|Open|OpenHelp|OpenNotebook|Optimize|PCA|ParseOperationTemplate|PathInfo|PauseForUser|PauseUpdate|PlayMovie|PlayMovieAction|PlaySound|PopupContextualMenu|PopupMenu|Preferences|PrimeFactors|Print|PrintGraphs|PrintLayout|PrintNotebook|PrintSettings|PrintTable|Project|PulseStats|PutScrapText|Quit|RatioFromNumber|Redimension|Remez|Remove|RemoveContour|RemoveFromGizmo|RemoveFromGraph|RemoveFromLayout|RemoveFromTable|RemoveImage|RemoveLayoutObjects|RemovePath|Rename|RenameDataFolder|RenamePICT|RenamePath|RenameWindow|ReorderImages|ReorderTraces|ReplaceText|ReplaceWave|Resample|ResumeUpdate|Reverse|Rotate|SQLHighLevelOp|STFT|Save|SaveData|SaveExperiment|SaveGizmoCopy|SaveGraphCopy|SaveNotebook|SavePICT|SavePackagePreferences|SaveTableCopy|SetActiveSubwindow|SetAxis|SetBackground|SetDashPattern|SetDataFolder|SetDimLabel|SetDrawEnv|SetDrawLayer|SetFileFolderInfo|SetFormula|SetIdlePeriod|SetIgorHook|SetIgorMenuMode|SetIgorOption|SetMarquee|SetProcessSleep|SetRandomSeed|SetScale|SetVariable|SetWaveLock|SetWaveTextEncoding|SetWindow|ShowIgorMenus|ShowInfo|ShowTools|Silent|Sleep|Slider|Smooth|SmoothCustom|Sort|SortColumns|SoundInRecord|SoundInSet|SoundInStartChart|SoundInStatus|SoundInStopChart|SoundLoadWave|SoundSaveWave|SphericalInterpolate|SphericalTriangulate|SplitString|SplitWave|Stack|StackWindows|StatsANOVA1Test|StatsANOVA2NRTest|StatsANOVA2RMTest|StatsANOVA2Test|StatsAngularDistanceTest|StatsChiTest|StatsCircularCorrelationTest|StatsCircularMeans|StatsCircularMoments|StatsCircularTwoSampleTest|StatsCochranTest|StatsContingencyTable|StatsDIPTest|StatsDunnettTest|StatsFTest|StatsFriedmanTest|StatsHodgesAjneTest|StatsJBTest|StatsKDE|StatsKSTest|StatsKWTest|StatsKendallTauTest|StatsLinearCorrelationTest|StatsLinearRegression|StatsMultiCorrelationTest|StatsNPMCTest|StatsNPNominalSRTest|StatsQuantiles|StatsRankCorrelationTest|StatsResample|StatsSRTest|StatsSample|StatsScheffeTest|StatsShapiroWilkTest|StatsSignTest|StatsTTest|StatsTukeyTest|StatsVariancesTest|StatsWRCorrelationTest|StatsWatsonUSquaredTest|StatsWatsonWilliamsTest|StatsWheelerWatsonTest|StatsWilcoxonRankTest|String|StructFill|StructGet|StructPut|SumDimension|SumSeries|TDMLoadData|TDMSaveData|TabControl|Tag|TextBox|ThreadGroupPutDF|ThreadStart|TickWavesFromAxis|Tile|TileWindows|TitleBox|ToCommandLine|ToolsGrid|Triangulate3d|URLRequest|Unwrap|VDT2|VDTClosePort2|VDTGetPortList2|VDTGetStatus2|VDTOpenPort2|VDTOperationsPort2|VDTRead2|VDTReadBinary2|VDTReadBinaryWave2|VDTReadHex2|VDTReadHexWave2|VDTReadWave2|VDTTerminalPort2|VDTWrite2|VDTWriteBinary2|VDTWriteBinaryWave2|VDTWriteHex2|VDTWriteHexWave2|VDTWriteWave2|VISAControl|VISARead|VISAReadBinary|VISAReadBinaryWave|VISAReadWave|VISAWrite|VISAWriteBinary|VISAWriteBinaryWave|VISAWriteWave|ValDisplay|Variable|WaveClear|WaveMeanStdv|WaveStats|WaveTransform|WignerTransform|WindowFunction|XLLoadWave|cd|dir|fprintf|printf|pwd|sprintf|sscanf|wfprintf)\b</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.igor</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Operations built into Igor</string>
 			<key>end</key>
 			<string>\s(?![\/])|$</string>
-			<key>name</key>
-			<string>entity.name.tag</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -467,12 +473,17 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.igor</string>
+							<string>constant.igor</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.igor</string>
 						</dict>
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.igor</string>
+							<string>source.igor</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -485,8 +496,6 @@
 							<string>source.igor</string>
 						</dict>
 					</dict>
-					<key>name</key>
-					<string>keyword.igor</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -291,7 +291,7 @@
 			<key>end</key>
 			<string>"</string>
 			<key>name</key>
-			<string>entity.name.tag</string>
+			<string>entity.name.tag.igor</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -26,17 +26,17 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.modifier.static.igor</string>
+					<string>entity.name.constant.igor</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>support.type.igor</string>
+					<string>entity.name.constant.igor</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.type.igor</string>
+					<string>source.igor</string>
 				</dict>
 			</dict>
 			<key>comment</key>
@@ -48,7 +48,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.type.igor</string>
+					<string>entity.name.constant.igor</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -74,27 +74,27 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>storage.modifier.static.igor</string>
+					<string>keyword.igor</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.type.igor</string>
+					<string>keyword.igor</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.igor</string>
+					<string>source.igor</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.igor</string>
+					<string>entity.name.igor</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.igor</string>
+					<string>brackethighlighter.round.igor</string>
 				</dict>
 			</dict>
 			<key>comment</key>
@@ -106,7 +106,7 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.igor</string>
+					<string>brackethighlighter.round.igor</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -135,7 +135,7 @@
 			<key>match</key>
 			<string>(?i)\b(?:V|S)_[A-Z]+\b</string>
 			<key>name</key>
-			<string>support.variable.igor</string>
+			<string>source.igor</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -145,7 +145,7 @@
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
-			<string>meta.preprocessor.igor</string>
+			<string>entity.name.igor</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -158,7 +158,11 @@
 					<key>end</key>
 					<string>\&gt;</string>
 					<key>name</key>
-					<string>string.other.igor</string>
+					<string>source.igor</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#igor_comment</string>
 				</dict>
 			</array>
 		</dict>
@@ -168,7 +172,7 @@
 			<key>match</key>
 			<string>^#\w+</string>
 			<key>name</key>
-			<string>meta.preprocessor.igor</string>
+			<string>entity.name.igor</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -178,7 +182,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.igor</string>
+					<string>entity.name.tag.igor</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -238,19 +242,19 @@
 					<key>match</key>
 					<string>(0x[a-f0-9]+)</string>
 					<key>name</key>
-					<string>constant.numeric.igor</string>
+					<string>constant.other.igor</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>([\d]+)</string>
 					<key>name</key>
-					<string>constant.numeric.integer.igor</string>
+					<string>constant.other.igor</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>(\d+\.\d+(e[\+\-]?\d+)?)</string>
 					<key>name</key>
-					<string>constant.numeric.float.igor</string>
+					<string>constant.other.igor</string>
 				</dict>
 			</array>
 		</dict>
@@ -264,13 +268,19 @@
 					<key>match</key>
 					<string>([\#$~!%^&amp;*+=\|?:&lt;&gt;/-])</string>
 					<key>name</key>
-					<string>keyword.operator.igor</string>
+					<string>source.igor</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>([{}()\[\],.;])</string>
+					<string>([,.;])</string>
 					<key>name</key>
-					<string>punctuation.igor</string>
+					<string>source.igor</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([{}()\[\]])</string>
+					<key>name</key>
+					<string>brackethighlighter.tag</string>
 				</dict>
 			</array>
 		</dict>
@@ -299,7 +309,7 @@
 			<key>match</key>
 			<string>(?i)\b(?:sqrt|cbrt|sin|cos|tan|asin|acos|atan|atan2|log|log10|exp|pow|sinh|cosh|tanh|asinh|acosh|atanh|factorial|pi|nan|sgn|floor|ceil|gcd|lcd|comp|sum|mean|variance|skew|kurtosis)\b</string>
 			<key>name</key>
-			<string>support.other.igor</string>
+			<string>entity.name.constant.igor</string>
 		</dict>
 		<key>igor_comment</key>
 		<dict>
@@ -310,14 +320,14 @@
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
-			<string>comment.double-slash.igor</string>
+			<string>message.error.igor</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
 					<string>\s\@\w+(?:\[\w+\])?</string>
 					<key>name</key>
-					<string>keyword.other.igor</string>
+					<string>comment.igor</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -356,7 +366,7 @@
 					<key>match</key>
 					<string>\w+(?=[\(])</string>
 					<key>name</key>
-					<string>meta.function-call.igor</string>
+					<string>entity.name.igor</string>
 				</dict>
 			</array>
 		</dict>
@@ -376,13 +386,13 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.separator.igor</string>
+							<string>brackethighlighter.square.igor</string>
 						</dict>
 					</dict>
 					<key>end</key>
 					<string>(\])</string>
 					<key>name</key>
-					<string>variable.parameter.optional.igor</string>
+					<string>source.igor</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -400,7 +410,7 @@
 			<key>match</key>
 			<string>(?i)\b(?:AddListItem|AiryA|AiryAD|AiryB|AiryBD|AnnotationInfo|AnnotationList|AxisInfo|AxisList|AxisValFromPixel|AxonTelegraphAGetDataNum|AxonTelegraphAGetDataString|AxonTelegraphAGetDataStruct|AxonTelegraphGetDataNum|AxonTelegraphGetDataString|AxonTelegraphGetDataStruct|AxonTelegraphGetTimeoutMs|AxonTelegraphSetTimeoutMs|Base64Decode|Base64Encode|Besseli|Besselj|Besselk|Bessely|BinarySearch|BinarySearchInterp|CTabList|CaptureHistory|CaptureHistoryStart|CheckName|ChildWindowList|CleanupName|ContourInfo|ContourNameList|ContourNameToWaveRef|ContourZ|ControlNameList|ConvertTextEncoding|CountObjects|CountObjectsDFR|CreationDate|CsrInfo|CsrWave|CsrWaveRef|CsrXWave|CsrXWaveRef|DataFolderDir|DataFolderExists|DataFolderRefStatus|DataFolderRefsEqual|DateToJulian|Dawson|DimDelta|DimOffset|DimSize|Faddeeva|FetchURL|FindDimLabel|FindListItem|FontList|FontSizeHeight|FontSizeStringWidth|FresnelCos|FresnelSin|FuncRefInfo|FunctionInfo|FunctionList|FunctionPath|GISGetAllFileFormats|GISSRefsAreEqual|Gauss|Gauss1D|Gauss2D|GetBrowserLine|GetBrowserSelection|GetDataFolder|GetDataFolderDFR|GetDefaultFont|GetDefaultFontSize|GetDefaultFontStyle|GetDimLabel|GetEnvironmentVariable|GetErrMessage|GetFormula|GetIndependentModuleName|GetIndexedObjName|GetIndexedObjNameDFR|GetKeyState|GetRTErrMessage|GetRTError|GetRTLocInfo|GetRTLocation|GetRTStackInfo|GetScrapText|GetUserData|GetWavesDataFolder|GetWavesDataFolderDFR|GizmoInfo|GizmoScale|GrepList|GrepString|GuideInfo|GuideNameList|HDF5AttributeInfo|HDF5DatasetInfo|HDF5LibraryInfo|HDF5TypeInfo|Hash|HyperG0F1|HyperG1F1|HyperG2F1|HyperGNoise|HyperGPFQ|IgorInfo|IgorVersion|ImageInfo|ImageNameList|ImageNameToWaveRef|IndependentModuleList|IndexToScale|IndexedDir|IndexedFile|Inf|Integrate1D|Interp2D|Interp3D|ItemsInList|JacobiCn|JacobiSn|JSON_CreateStructured|JSON_Kill|JSON_GetType|JSON_GetArraySize|JSON_GetMaxArraySize|JSON_Parse|JSON_Dump|JulianToDate|Laguerre|LaguerreA|LaguerreGauss|LambertW|LayoutInfo|LegendreA|ListMatch|ListToTextWave|ListToWaveRefWave|LowerStr|MCC_AutoBridgeBal|MCC_AutoFastComp|MCC_AutoPipetteOffset|MCC_AutoSlowComp|MCC_AutoWholeCellComp|MCC_GetBridgeBalEnable|MCC_GetBridgeBalResist|MCC_GetFastCompCap|MCC_GetFastCompTau|MCC_GetHolding|MCC_GetHoldingEnable|MCC_GetMode|MCC_GetNeutralizationCap|MCC_GetNeutralizationEnable|MCC_GetOscKillerEnable|MCC_GetPipetteOffset|MCC_GetPrimarySignalGain|MCC_GetPrimarySignalHPF|MCC_GetPrimarySignalLPF|MCC_GetRsCompBandwidth|MCC_GetRsCompCorrection|MCC_GetRsCompEnable|MCC_GetRsCompPrediction|MCC_GetSecondarySignalGain|MCC_GetSecondarySignalLPF|MCC_GetSlowCompCap|MCC_GetSlowCompTau|MCC_GetSlowCompTauX20Enable|MCC_GetSlowCurrentInjEnable|MCC_GetSlowCurrentInjLevel|MCC_GetSlowCurrentInjSetlTime|MCC_GetWholeCellCompCap|MCC_GetWholeCellCompEnable|MCC_GetWholeCellCompResist|MCC_SelectMultiClamp700B|MCC_SetBridgeBalEnable|MCC_SetBridgeBalResist|MCC_SetFastCompCap|MCC_SetFastCompTau|MCC_SetHolding|MCC_SetHoldingEnable|MCC_SetMode|MCC_SetNeutralizationCap|MCC_SetNeutralizationEnable|MCC_SetOscKillerEnable|MCC_SetPipetteOffset|MCC_SetPrimarySignalGain|MCC_SetPrimarySignalHPF|MCC_SetPrimarySignalLPF|MCC_SetRsCompBandwidth|MCC_SetRsCompCorrection|MCC_SetRsCompEnable|MCC_SetRsCompPrediction|MCC_SetSecondarySignalGain|MCC_SetSecondarySignalLPF|MCC_SetSlowCompCap|MCC_SetSlowCompTau|MCC_SetSlowCompTauX20Enable|MCC_SetSlowCurrentInjEnable|MCC_SetSlowCurrentInjLevel|MCC_SetSlowCurrentInjSetlTime|MCC_SetTimeoutMs|MCC_SetWholeCellCompCap|MCC_SetWholeCellCompEnable|MCC_SetWholeCellCompResist|MPFXEMGPeak|MPFXExpConvExpPeak|MPFXGaussPeak|MPFXLorenzianPeak|MPFXVoigtPeak|MacroList|MandelbrotPoint|MarcumQ|MatrixCondition|MatrixDet|MatrixDot|MatrixRank|MatrixTrace|ModDate|NVAR_Exists|NaN|NameOfWave|NewFreeDataFolder|NewFreeWave|NormalizeUnicode|NumVarOrDefault|NumberByKey|OperationList|PICTInfo|PICTList|PadString|PanelResolution|ParamIsDefault|ParseFilePath|PathList|Pi|PixelFromAxisVal|PolygonArea|PossiblyQuoteName|ProcedureText|RemoveByKey|RemoveEnding|RemoveFromList|RemoveListItem|ReplaceNumberByKey|ReplaceString|ReplaceStringByKey|SQL2DBinaryWaveToTextWave|SQLAllocHandle|SQLAllocStmt|SQLBinaryWavesToTextWave|SQLBindCol|SQLBindParameter|SQLBrowseConnect|SQLBulkOperations|SQLCancel|SQLCloseCursor|SQLColAttributeNum|SQLColAttributeStr|SQLColumnPrivileges|SQLColumns|SQLConnect|SQLDataSources|SQLDescribeCol|SQLDescribeParam|SQLDisconnect|SQLDriverConnect|SQLDrivers|SQLEndTran|SQLError|SQLExecDirect|SQLExecute|SQLFetch|SQLFetchScroll|SQLForeignKeys|SQLFreeConnect|SQLFreeEnv|SQLFreeHandle|SQLFreeStmt|SQLGetConnectAttrNum|SQLGetConnectAttrStr|SQLGetCursorName|SQLGetDataNum|SQLGetDataStr|SQLGetDescFieldNum|SQLGetDescFieldStr|SQLGetDescRec|SQLGetDiagFieldNum|SQLGetDiagFieldStr|SQLGetDiagRec|SQLGetEnvAttrNum|SQLGetEnvAttrStr|SQLGetFunctions|SQLGetInfoNum|SQLGetInfoStr|SQLGetStmtAttrNum|SQLGetStmtAttrStr|SQLGetTypeInfo|SQLMoreResults|SQLNativeSql|SQLNumParams|SQLNumResultCols|SQLNumResultRowsIfKnown|SQLNumRowsFetched|SQLParamData|SQLPrepare|SQLPrimaryKeys|SQLProcedureColumns|SQLProcedures|SQLPutData|SQLReinitialize|SQLRowCount|SQLSetConnectAttrNum|SQLSetConnectAttrStr|SQLSetCursorName|SQLSetDescFieldNum|SQLSetDescFieldStr|SQLSetDescRec|SQLSetEnvAttrNum|SQLSetEnvAttrStr|SQLSetPos|SQLSetStmtAttrNum|SQLSetStmtAttrStr|SQLSpecialColumns|SQLStatistics|SQLTablePrivileges|SQLTables|SQLTextWaveTo2DBinaryWave|SQLTextWaveToBinaryWaves|SQLUpdateBoundValues|SQLXOPCheckState|SVAR_Exists|ScreenResolution|Secs2Date|Secs2Time|SelectNumber|SelectString|SetEnvironmentVariable|SortList|SpecialCharacterInfo|SpecialCharacterList|SpecialDirPath|SphericalBessJ|SphericalBessJD|SphericalBessY|SphericalBessYD|SphericalHarmonics|StartMSTimer|StatsBetaCDF|StatsBetaPDF|StatsBinomialCDF|StatsBinomialPDF|StatsCMSSDCDF|StatsCauchyCDF|StatsCauchyPDF|StatsChiCDF|StatsChiPDF|StatsCorrelation|StatsDExpCDF|StatsDExpPDF|StatsEValueCDF|StatsEValuePDF|StatsErlangCDF|StatsErlangPDF|StatsErrorPDF|StatsExpCDF|StatsExpPDF|StatsFCDF|StatsFPDF|StatsFriedmanCDF|StatsGEVCDF|StatsGEVPDF|StatsGammaCDF|StatsGammaPDF|StatsGeometricCDF|StatsGeometricPDF|StatsHyperGCDF|StatsHyperGPDF|StatsInvBetaCDF|StatsInvBinomialCDF|StatsInvCMSSDCDF|StatsInvCauchyCDF|StatsInvChiCDF|StatsInvDExpCDF|StatsInvEValueCDF|StatsInvExpCDF|StatsInvFCDF|StatsInvFriedmanCDF|StatsInvGammaCDF|StatsInvGeometricCDF|StatsInvKuiperCDF|StatsInvLogNormalCDF|StatsInvLogisticCDF|StatsInvMaxwellCDF|StatsInvMooreCDF|StatsInvNBinomialCDF|StatsInvNCChiCDF|StatsInvNCFCDF|StatsInvNormalCDF|StatsInvParetoCDF|StatsInvPoissonCDF|StatsInvPowerCDF|StatsInvQCDF|StatsInvQpCDF|StatsInvRayleighCDF|StatsInvRectangularCDF|StatsInvSpearmanCDF|StatsInvStudentCDF|StatsInvTopDownCDF|StatsInvTriangularCDF|StatsInvUsquaredCDF|StatsInvVonMisesCDF|StatsInvWeibullCDF|StatsKuiperCDF|StatsLogNormalCDF|StatsLogNormalPDF|StatsLogisticCDF|StatsLogisticPDF|StatsMaxwellCDF|StatsMaxwellPDF|StatsMedian|StatsMooreCDF|StatsNBinomialCDF|StatsNBinomialPDF|StatsNCChiCDF|StatsNCChiPDF|StatsNCFCDF|StatsNCFPDF|StatsNCTCDF|StatsNCTPDF|StatsNormalCDF|StatsNormalPDF|StatsParetoCDF|StatsParetoPDF|StatsPermute|StatsPoissonCDF|StatsPoissonPDF|StatsPowerCDF|StatsPowerNoise|StatsPowerPDF|StatsQCDF|StatsQpCDF|StatsRayleighCDF|StatsRayleighPDF|StatsRectangularCDF|StatsRectangularPDF|StatsRunsCDF|StatsSpearmanRhoCDF|StatsStudentCDF|StatsStudentPDF|StatsTopDownCDF|StatsTriangularCDF|StatsTriangularPDF|StatsTrimmedMean|StatsUSquaredCDF|StatsVonMisesCDF|StatsVonMisesNoise|StatsVonMisesPDF|StatsWaldCDF|StatsWaldPDF|StatsWeibullCDF|StatsWeibullPDF|StopMSTimer|StrVarOrDefault|StringByKey|StringFromList|StringList|StudentA|StudentT|TDMAddChannel|TDMAddGroup|TDMAppendDataValues|TDMAppendDataValuesTime|TDMChannelPropertyExists|TDMCloseChannel|TDMCloseFile|TDMCloseGroup|TDMCreateChannelProperty|TDMCreateFile|TDMCreateFileProperty|TDMCreateGroupProperty|TDMFilePropertyExists|TDMGetChannelPropertyNames|TDMGetChannelPropertyNum|TDMGetChannelPropertyStr|TDMGetChannelPropertyTime|TDMGetChannelPropertyType|TDMGetChannelStringPropertyLen|TDMGetChannels|TDMGetDataType|TDMGetDataValues|TDMGetDataValuesTime|TDMGetFilePropertyNames|TDMGetFilePropertyNum|TDMGetFilePropertyStr|TDMGetFilePropertyTime|TDMGetFilePropertyType|TDMGetFileStringPropertyLen|TDMGetGroupPropertyNames|TDMGetGroupPropertyNum|TDMGetGroupPropertyStr|TDMGetGroupPropertyTime|TDMGetGroupPropertyType|TDMGetGroupStringPropertyLen|TDMGetGroups|TDMGetLibraryErrorDescription|TDMGetNumChannelProperties|TDMGetNumChannels|TDMGetNumDataValues|TDMGetNumFileProperties|TDMGetNumGroupProperties|TDMGetNumGroups|TDMGroupPropertyExists|TDMOpenFile|TDMOpenFileEx|TDMRemoveChannel|TDMRemoveGroup|TDMReplaceDataValues|TDMReplaceDataValuesTime|TDMSaveFile|TDMSetChannelPropertyNum|TDMSetChannelPropertyStr|TDMSetChannelPropertyTime|TDMSetDataValues|TDMSetDataValuesTime|TDMSetFilePropertyNum|TDMSetFilePropertyStr|TDMSetFilePropertyTime|TDMSetGroupPropertyNum|TDMSetGroupPropertyStr|TDMSetGroupPropertyTime|TableInfo|TagVal|TagWaveRef|TextEncodingCode|TextEncodingName|TextFile|ThreadGroupCreate|ThreadGroupGetDF|ThreadGroupGetDFR|ThreadGroupRelease|ThreadGroupWait|ThreadProcessorCount|ThreadReturnValue|TraceFromPixel|TraceInfo|TraceNameList|TraceNameToWaveRef|TrimString|URLDecode|URLEncode|UnPadString|UniqueName|UnsetEnvironmentVariable|UpperStr|VariableList|Variance|VoigtFunc|VoigtPeak|WaveCRC|WaveDims|WaveExists|WaveHash|WaveInfo|WaveList|WaveMax|WaveMin|WaveName|WaveRefIndexed|WaveRefIndexedDFR|WaveRefWaveToList|WaveRefsEqual|WaveTextEncoding|WaveType|WaveUnits|WhichListItem|WinList|WinName|WinRecreation|WinType|XWaveName|XWaveRefFromTrace|ZernikeR|abs|acos|acosh|alog|area|areaXY|asin|asinh|atan|atan2|atanh|beta|betai|binomial|binomialNoise|binomialln|cabs|ceil|cequal|char2num|chebyshev|chebyshevU|cmplx|cmpstr|conj|cos|cosIntegral|cosh|cot|coth|cpowi|csc|csch|date|date2secs|datetime|defined|deltax|digamma|dilogarithm|ei|enoise|equalWaves|erf|erfc|erfcw|exists|exp|expInt|expIntegralE1|expNoise|fDAQmx_AI_GetReader|fDAQmx_AO_UpdateOutputs|fDAQmx_CTR_Finished|fDAQmx_CTR_IsFinished|fDAQmx_CTR_IsPulseFinished|fDAQmx_CTR_ReadCounter|fDAQmx_CTR_ReadWithOptions|fDAQmx_CTR_SetPulseFrequency|fDAQmx_CTR_Start|fDAQmx_ConnectTerminals|fDAQmx_DIO_Finished|fDAQmx_DIO_PortWidth|fDAQmx_DIO_Read|fDAQmx_DIO_Write|fDAQmx_DeviceNames|fDAQmx_DisconnectTerminals|fDAQmx_ErrorString|fDAQmx_ExternalCalDate|fDAQmx_NumAnalogInputs|fDAQmx_NumAnalogOutputs|fDAQmx_NumCounters|fDAQmx_NumDIOPorts|fDAQmx_ReadChan|fDAQmx_ReadNamedChan|fDAQmx_ResetDevice|fDAQmx_ScanGetAvailable|fDAQmx_ScanGetNextIndex|fDAQmx_ScanStart|fDAQmx_ScanStop|fDAQmx_ScanWait|fDAQmx_ScanWaitWithTimeout|fDAQmx_SelfCalDate|fDAQmx_SelfCalibration|fDAQmx_WF_IsFinished|fDAQmx_WF_WaitUntilFinished|fDAQmx_WaveformStart|fDAQmx_WaveformStop|fDAQmx_WriteChan|factorial|fakedata|faverage|faverageXY|floor|gamma|gammaEuler|gammaInc|gammaNoise|gammln|gammp|gammq|gcd|gnoise|hcsr|hermite|hermiteGauss|imag|interp|inverseERF|inverseERFC|leftx|limit|ln|log|logNormalNoise|lorentzianNoise|magsqr|max|mean|median|min|mod|norm|note|num2char|num2istr|num2str|numpnts|numtype|p2rect|pcsr|pnt2x|poissonNoise|poly|poly2D|qcsr|r2polar|real|rightx|round|sawtooth|scaleToIndex|sec|sech|sign|sin|sinIntegral|sinc|sinh|sqrt|str2num|stringCRC|stringmatch|strlen|strsearch|sum|tan|tango_close_device|tango_command_inout|tango_compute_image_proj|tango_get_dev_attr_list|tango_get_dev_black_box|tango_get_dev_cmd_list|tango_get_dev_status|tango_get_dev_timeout|tango_get_error_stack|tango_open_device|tango_ping_device|tango_read_attribute|tango_read_attributes|tango_reload_dev_interface|tango_resume_attr_monitor|tango_set_attr_monitor_period|tango_set_dev_timeout|tango_start_attr_monitor|tango_stop_attr_monitor|tango_suspend_attr_monitor|tango_write_attribute|tango_write_attributes|tanh|ticks|time|trunc|vcsr|viAssertIntrSignal|viAssertTrigger|viAssertUtilSignal|viClear|viClose|viDisableEvent|viDiscardEvents|viEnableEvent|viFindNext|viFindRsrc|viGetAttribute|viGetAttributeString|viGpibCommand|viGpibControlATN|viGpibControlREN|viGpibPassControl|viGpibSendIFC|viIn16|viIn32|viIn8|viLock|viMapAddress|viMapTrigger|viMemAlloc|viMemFree|viMoveIn16|viMoveIn32|viMoveIn8|viMoveOut16|viMoveOut32|viMoveOut8|viOpen|viOpenDefaultRM|viOut16|viOut32|viOut8|viPeek16|viPeek32|viPeek8|viPoke16|viPoke32|viPoke8|viRead|viReadSTB|viSetAttribute|viSetAttributeString|viStatusDesc|viTerminate|viUnlock|viUnmapAddress|viUnmapTrigger|viUsbControlIn|viUsbControlOut|viVxiCommandQuery|viWaitOnEvent|viWrite|wnoise|x2pnt|xcsr|zcsr|zeromq_client_connect|zeromq_client_connect|zeromq_client_recv|zeromq_client_recv|zeromq_client_send|zeromq_client_send|zeromq_handler_start|zeromq_handler_start|zeromq_handler_stop|zeromq_handler_stop|zeromq_server_bind|zeromq_server_bind|zeromq_server_recv|zeromq_server_recv|zeromq_server_send|zeromq_server_send|zeromq_set|zeromq_set|zeromq_stop|zeromq_stop|zeromq_test_callfunction|zeromq_test_callfunction|zeromq_test_serializeWave|zeromq_test_serializeWave|zeta)\b</string>
 			<key>name</key>
-			<string>support.function.igor</string>
+			<string>variable.igor</string>
 		</dict>
 		<key>igor_matrixop</key>
 		<dict>
@@ -409,7 +419,7 @@
 			<key>match</key>
 			<string>(?i)\b(?:abs|acos|acosh|asin|asinh|asynccorrelation|atan|atan2|atanh|averageCols|axisToQuat|backwardSub|beam|bitAnd|bitNot|bitOr|bitShift|bitXor|catCols|catRows|cbrt|ceil|chirpz|chirpzf|chol|chunk|clip|cmplx|col|colRepeat|conj|Const|convolve|correlate|cos|cosh|covariance|crosscovar|Det|diagonal|diagrc|e|equal|erf|erfc|exp|fct|fft|floor|forwardSub|fp32|fp64|frobenius|fsct|fsct2|fsst|fsst2|fst|getDiag|greater|hypot|identity|ifft|imag|imageRestore|indexChunks|indexCols|indexLayers|indexRows|INF|insertMat|int16|int32|int8|Integrate|intMatrix|inv|InverseErf|InverseErfc|layer|limitProduct|ln|log|mag|magsqr|matrixToQuat|maxAB|maxCols|maxRows|maxVal|mean|MeanCols|minCols|minRows|minVal|mod|nan|normalize|normalizecols|normalizerows|numCols|numPoints|numRows|numType|outerProduct|p2rect|phase|pi|powc|powr|productCol|productCols|productDiagonal|productRow|productRows|quat|quatToAxis|quatToEuler|quatToMatrix|r2polar|real|rec|redimension|replace|replacenans|reverseCol|reverseCols|reverseRow|reverseRows|rotateChunks|rotateCols|rotateLayers|rotateRows|round|row|rowRepeat|scale|scaleCols|scaleRows|setCol|setNaNs|setOffDiag|setRow|sgn|shiftvector|sin|sinh|slerp|sqrt|subrange|subtractmean|subWaveC|subWaveR|sum|sumBeams|sumcols|sumRows|sumsqr|synccorrelation|tan|tanh|tensorProduct|Trace|transposeVol|tridiag|uint16|uint32|uint8|varcols|vwl|waveChunks|waveIndexSet|waveLayers|wavemap|wavemap2|wavePoints|within|ZeroMat)\b</string>
 			<key>name</key>
-			<string>support.other.igor</string>
+			<string>entity.name.constant.igor</string>
 		</dict>
 		<key>igor_operations</key>
 		<dict>
@@ -420,7 +430,7 @@
 			<key>end</key>
 			<string>\s(?![\/])|$</string>
 			<key>name</key>
-			<string>support.class.igor</string>
+			<string>entity.name.tag</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -431,7 +441,7 @@
 					<key>end</key>
 					<string>(?=\/|\s|=|\")</string>
 					<key>name</key>
-					<string>support.class.modifier.igor</string>
+					<string>source.igor</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -457,12 +467,12 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>storage.modifier.static.igor</string>
+							<string>keyword.igor</string>
 						</dict>
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>storage.modifier.igor</string>
+							<string>keyword.igor</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -472,11 +482,11 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.operator.assignment.igor</string>
+							<string>source.igor</string>
 						</dict>
 					</dict>
 					<key>name</key>
-					<string>storage.type.igor</string>
+					<string>keyword.igor</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -487,13 +497,13 @@
 							<key>match</key>
 							<string>,</string>
 							<key>name</key>
-							<string>punctuation.separator.variable.igor</string>
+							<string>source.igor</string>
 						</dict>
 						<dict>
 							<key>match</key>
 							<string>\w</string>
 							<key>name</key>
-							<string>variable.igor</string>
+							<string>source.igor</string>
 						</dict>
 					</array>
 				</dict>

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -211,7 +211,23 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#igor_basic</string>
+			<string>#igor_operations</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>inline wave assignments</string>
+			<key>match</key>
+			<string>(?i)\/wave(?=\=)</string>
+			<key>name</key>
+			<string>constant.igor</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#igor_functions</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#igor_common</string>
 		</dict>
 	</array>
 	<key>repository</key>
@@ -295,34 +311,6 @@
 			<key>name</key>
 			<string>constant.igor</string>
 		</dict>
-		<key>igor_basic</key>
-		<dict>
-			<key>comment</key>
-			<string>all basic syntax that can exist in functions and macros</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#igor_operations</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>inline wave assignments</string>
-					<key>match</key>
-					<string>(?i)\/wave(?=\=)</string>
-					<key>name</key>
-					<string>constant.igor</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#igor_functions</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#igor_common</string>
-				</dict>
-			</array>
-		</dict>
 		<key>igor_comment</key>
 		<dict>
 			<key>begin</key>
@@ -350,7 +338,11 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#igor_basic</string>
+							<string>#igor_functions</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#igor_common</string>
 						</dict>
 					</array>
 				</dict>
@@ -375,10 +367,8 @@
 					<string>#constant_numeric</string>
 				</dict>
 				<dict>
-					<key>match</key>
-					<string>\w+(?:\#\w+)(?=[\(])</string>
-					<key>name</key>
-					<string>entity.name.igor</string>
+					<key>include</key>
+					<string>#user_functions</string>
 				</dict>
 			</array>
 		</dict>
@@ -448,7 +438,7 @@
 			<key>comment</key>
 			<string>Operations built into Igor</string>
 			<key>end</key>
-			<string>\s(?![\/])|\s</string>
+			<string>\s(?![\/])|$</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -460,6 +450,14 @@
 					<string>(?=\/|\s|=|\")</string>
 					<key>name</key>
 					<string>source.igor</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#igor_functions</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#igor_common</string>
 				</dict>
 			</array>
 		</dict>
@@ -519,6 +517,20 @@
 							<string>source.igor</string>
 						</dict>
 					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>user_functions</key>
+		<dict>
+			<key>comment</key>
+			<string>user functions are optionally highlighted in IP8</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>([\w\#]+)(?=[\(])</string>
+					<key>name</key>
+					<string>entity.name.igor</string>
 				</dict>
 			</array>
 		</dict>

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -291,7 +291,7 @@
 			<key>end</key>
 			<string>"</string>
 			<key>name</key>
-			<string>string.quoted.double.igor</string>
+			<string>entity.name.tag</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/igorpro.tmLanguage
+++ b/igorpro.tmLanguage
@@ -211,23 +211,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#igor_operations</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>inline wave assignments</string>
-			<key>match</key>
-			<string>(?i)\/wave(?=\=)</string>
-			<key>name</key>
-			<string>constant.igor</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#igor_functions</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#igor_common</string>
+			<string>#igor_basic</string>
 		</dict>
 	</array>
 	<key>repository</key>
@@ -311,6 +295,34 @@
 			<key>name</key>
 			<string>constant.igor</string>
 		</dict>
+		<key>igor_basic</key>
+		<dict>
+			<key>comment</key>
+			<string>all basic syntax that can exist in functions and macros</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#igor_operations</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>inline wave assignments</string>
+					<key>match</key>
+					<string>(?i)\/wave(?=\=)</string>
+					<key>name</key>
+					<string>constant.igor</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#igor_functions</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#igor_common</string>
+				</dict>
+			</array>
+		</dict>
 		<key>igor_comment</key>
 		<dict>
 			<key>begin</key>
@@ -338,7 +350,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#igor_common</string>
+							<string>#igor_basic</string>
 						</dict>
 					</array>
 				</dict>
@@ -436,7 +448,7 @@
 			<key>comment</key>
 			<string>Operations built into Igor</string>
 			<key>end</key>
-			<string>\s(?![\/])|$</string>
+			<string>\s(?![\/])|\s</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -448,14 +460,6 @@
 					<string>(?=\/|\s|=|\")</string>
 					<key>name</key>
 					<string>source.igor</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#igor_functions</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#igor_common</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
To match up with the typical Igor Pro Color style for most of the
defined elements, the igor types are mapped to match up with Githubs
colors.

A php script to find the closes Github Color is included.